### PR TITLE
feat: playbook.ymlにasdfバージョン管理の設定を追加し、.tool-versionsファイルの存在確認やプラグインのインストールを行うタスクを実装

### DIFF
--- a/infra/playbook.yml
+++ b/infra/playbook.yml
@@ -11,6 +11,7 @@
       age_key: "{{ ansible_env.HOME }}/.config/age/age.key"
       chezmoi_source: "{{ ansible_env.HOME }}/.local/share/chezmoi"
       zprofile: "{{ ansible_env.HOME }}/.zprofile"
+      tool_versions: "{{ ansible_env.HOME }}/.tool-versions"
 
     brew_configs:
       Darwin_arm64: &darwin_arm
@@ -42,6 +43,10 @@
         msg: "Unsupported platform: {{ ansible_facts.os_family }}/{{ ansible_facts.machine }}"
       when: brew == {}
 
+    - name: Set asdf configuration
+      set_fact:
+        asdf_sh: "{{ brew.prefix }}/opt/asdf/libexec/asdf.sh"
+
   tasks:
     - name: Check Homebrew installation
       command: "{{ brew.bin }}/brew --version"
@@ -62,6 +67,7 @@
       loop:
         - 'eval "$({{ brew.bin }}/brew shellenv)"'
         - 'export AGE_IDENTITIES_FILE="{{ paths.age_key }}"'
+        - '. {{ asdf_sh }}'
 
     - name: Install system dependencies
       apt:
@@ -179,6 +185,86 @@
       environment:
         AGE_IDENTITIES_FILE: "{{ paths.age_key }}"
 
+    - name: Setup asdf version management
+      block:
+        - name: Check .tool-versions file exists
+          stat:
+            path: "{{ paths.tool_versions }}"
+          register: tool_versions_file
+
+        - name: Read .tool-versions content
+          slurp:
+            src: "{{ paths.tool_versions }}"
+          register: tool_versions_raw
+          when: tool_versions_file.stat.exists
+
+        - name: Parse .tool-versions content
+          set_fact:
+            asdf_tools: >-
+              {{
+                (tool_versions_raw.content | b64decode).splitlines()
+                | map('trim')
+                | reject('match', '^(#|$)')
+                | map('split')
+                | list
+              }}
+          when: 
+            - tool_versions_file.stat.exists
+            - tool_versions_raw.content is defined
+
+        - name: Display detected tools
+          debug:
+            msg: "Detected asdf tools: {{ asdf_tools | map('join', ' ') | list | join(', ') }}"
+          when: asdf_tools is defined and asdf_tools | length > 0
+
+        - name: Get currently installed plugins
+          shell: '. "{{ asdf_sh }}" && asdf plugin list'
+          register: installed_plugins
+          changed_when: false
+          failed_when: false
+          when: asdf_tools is defined
+
+        - name: Install missing asdf plugins
+          shell: '. "{{ asdf_sh }}" && asdf plugin add {{ item[0] }}'
+          loop: "{{ asdf_tools }}"
+          when: 
+            - asdf_tools is defined
+            - item[0] not in (installed_plugins.stdout_lines | default([]))
+          register: plugin_results
+          failed_when: false
+
+        - name: Handle nodejs plugin requirements
+          shell: '. "{{ asdf_sh }}" && bash ~/.asdf/plugins/nodejs/bin/import-release-team-keyring'
+          when: 
+            - asdf_tools is defined
+            - asdf_tools | map('first') | list | select('match', 'nodejs') | list | length > 0
+          failed_when: false
+          changed_when: false
+
+        - name: Install tools from .tool-versions
+          shell: '. "{{ asdf_sh }}" && cd "{{ paths.home }}" && asdf install'
+          when: asdf_tools is defined
+          register: install_result
+
+        - name: Reshim asdf executables
+          shell: '. "{{ asdf_sh }}" && asdf reshim'
+          when: asdf_tools is defined
+
+        - name: Verify asdf current versions
+          shell: '. "{{ asdf_sh }}" && asdf current'
+          register: asdf_current
+          changed_when: false
+          when: asdf_tools is defined
+
+        - name: Display installed versions
+          debug:
+            msg: "{{ asdf_current.stdout_lines }}"
+          when: 
+            - asdf_tools is defined
+            - asdf_current.stdout_lines is defined
+
+      when: tool_versions_file.stat.exists
+
     - name: Verify installation
       block:
         - name: Check tool versions
@@ -196,3 +282,4 @@
               - "Configuration: {{ paths.chezmoi_config }}/chezmoi.toml"
               - "Status: {{ final_status.stdout_lines | join(', ') if final_status.stdout_lines else 'Clean' }}"
               - "Tools: {{ versions.results | selectattr('rc', 'equalto', 0) | map(attribute='item') | list | join(', ') }}"
+              - "ASDF Tools: {{ asdf_tools | map('join', ' ') | list | join(', ') if asdf_tools is defined else 'None detected' }}"

--- a/infra/playbook.yml
+++ b/infra/playbook.yml
@@ -73,12 +73,42 @@
         - 'export ASDF_DIR="{{ brew.prefix }}/opt/asdf/libexec"'
         - '. {{ asdf_sh }}'
 
-    - name: Install system dependencies
-      apt:
-        name: build-essential
-        update_cache: yes
-      become: yes
-      when: ansible_facts.os_family == "Debian"
+    - name: Install essential system dependencies
+      block:
+        - name: Install core dependencies (Debian/Ubuntu)
+          apt:
+            name: 
+              # 基本ツール
+              - build-essential
+              - unzip
+              - curl
+              - wget
+              - git
+              - gnupg
+              - dirmngr
+              - ca-certificates
+              - software-properties-common
+              # 開発用ライブラリ（Python/Ruby等で必要）
+              - libssl-dev
+              - libffi-dev
+              - zlib1g-dev
+              - libbz2-dev
+              - libreadline-dev
+              - libsqlite3-dev
+              - xz-utils
+            update_cache: yes
+            state: present
+          become: yes
+          when: ansible_facts.os_family == "Debian"
+
+        - name: Install core dependencies (macOS)
+          community.general.homebrew:
+            name:
+              - unzip
+              - gnupg
+            state: present
+          when: ansible_facts.os_family == "Darwin"
+
 
     - name: Check existing packages
       command: "{{ brew.bin }}/brew list --versions {{ item }}"

--- a/infra/playbook.yml
+++ b/infra/playbook.yml
@@ -46,6 +46,9 @@
     - name: Set asdf configuration
       set_fact:
         asdf_sh: "{{ brew.prefix }}/opt/asdf/libexec/asdf.sh"
+        asdf_env:
+          ASDF_DIR: "{{ brew.prefix }}/opt/asdf/libexec"
+          PATH: "{{ ansible_env.PATH }}:{{ brew.prefix }}/opt/asdf/shims:{{ brew.prefix }}/opt/asdf/bin"
 
   tasks:
     - name: Check Homebrew installation
@@ -67,6 +70,7 @@
       loop:
         - 'eval "$({{ brew.bin }}/brew shellenv)"'
         - 'export AGE_IDENTITIES_FILE="{{ paths.age_key }}"'
+        - 'export ASDF_DIR="{{ brew.prefix }}/opt/asdf/libexec"'
         - '. {{ asdf_sh }}'
 
     - name: Install system dependencies
@@ -218,6 +222,8 @@
           register: installed_plugins
           changed_when: false
           failed_when: false
+          args:
+            executable: /bin/bash
 
         - name: Install missing asdf plugins
           shell: '. "{{ asdf_sh }}" && asdf plugin add {{ item[0] }}'
@@ -225,8 +231,9 @@
           when: 
             - asdf_tools is defined
             - item[0] not in (installed_plugins.stdout_lines | default([]))
-          register: plugin_results
           failed_when: false
+          args:
+            executable: /bin/bash
 
         - name: Handle nodejs plugin requirements
           shell: '. "{{ asdf_sh }}" && bash ~/.asdf/plugins/nodejs/bin/import-release-team-keyring'
@@ -235,21 +242,28 @@
             - asdf_tools | map('first') | list | select('match', 'nodejs') | list | length > 0
           failed_when: false
           changed_when: false
+          args:
+            executable: /bin/bash
 
         - name: Install tools from .tool-versions
           shell: '. "{{ asdf_sh }}" && cd "{{ paths.home }}" && asdf install'
           when: asdf_tools is defined
-          register: install_result
+          args:
+            executable: /bin/bash
 
         - name: Reshim asdf executables
           shell: '. "{{ asdf_sh }}" && asdf reshim'
           when: asdf_tools is defined
+          args:
+            executable: /bin/bash
 
         - name: Verify asdf current versions
           shell: '. "{{ asdf_sh }}" && asdf current'
           register: asdf_current
           changed_when: false
           when: asdf_tools is defined
+          args:
+            executable: /bin/bash
 
         - name: Display installed versions
           debug:
@@ -258,7 +272,9 @@
             - asdf_tools is defined
             - asdf_current.stdout_lines is defined
 
-      when: tool_versions_file.stat.exists  # 既に定義済みの変数を参照
+      environment: "{{ asdf_env }}"
+      when: tool_versions_file.stat.exists
+
 
     - name: Display skip message
       debug:

--- a/infra/playbook.yml
+++ b/infra/playbook.yml
@@ -184,19 +184,18 @@
 
       environment:
         AGE_IDENTITIES_FILE: "{{ paths.age_key }}"
+    
+    - name: Check .tool-versions file exists
+      stat:
+        path: "{{ paths.tool_versions }}"
+      register: tool_versions_file
 
     - name: Setup asdf version management
       block:
-        - name: Check .tool-versions file exists
-          stat:
-            path: "{{ paths.tool_versions }}"
-          register: tool_versions_file
-
         - name: Read .tool-versions content
           slurp:
             src: "{{ paths.tool_versions }}"
           register: tool_versions_raw
-          when: tool_versions_file.stat.exists
 
         - name: Parse .tool-versions content
           set_fact:
@@ -208,9 +207,6 @@
                 | map('split')
                 | list
               }}
-          when: 
-            - tool_versions_file.stat.exists
-            - tool_versions_raw.content is defined
 
         - name: Display detected tools
           debug:
@@ -222,7 +218,6 @@
           register: installed_plugins
           changed_when: false
           failed_when: false
-          when: asdf_tools is defined
 
         - name: Install missing asdf plugins
           shell: '. "{{ asdf_sh }}" && asdf plugin add {{ item[0] }}'
@@ -263,7 +258,12 @@
             - asdf_tools is defined
             - asdf_current.stdout_lines is defined
 
-      when: tool_versions_file.stat.exists
+      when: tool_versions_file.stat.exists  # 既に定義済みの変数を参照
+
+    - name: Display skip message
+      debug:
+        msg: "Skipping asdf setup: .tool-versions file not found at {{ paths.tool_versions }}"
+      when: not tool_versions_file.stat.exists
 
     - name: Verify installation
       block:


### PR DESCRIPTION
## 概要
本PRは、Ansibleプレイブック（`playbook.yml`）にasdfバージョン管理システムの設定を追加し、開発環境のツール管理を自動化する機能を実装しています。

## 主な変更内容

### 1. asdf設定の追加
- **設定項目の定義**: `.tool-versions`ファイルのパスを変数として定義
- **asdf環境変数の設定**: asdfシェルスクリプトのパス設定とbashシェル実行環境の構成
- **asdf初期化**: Homebrew経由でインストールされたasdfの適切な設定

### 2. .tool-versionsファイル処理
- **存在確認**: `.tool-versions`ファイルの存在をチェック
- **内容解析**: ファイル内容を読み取り、定義されているツールとバージョンを解析
- **コメント・空行除外**: `#`で始まるコメント行や空行を適切に除外

### 3. asdfプラグイン管理
- **既存プラグイン確認**: インストール済みのasdfプラグインを確認
- **不足プラグインのインストール**: 必要なプラグインを自動的にインストール
- **Node.js特別対応**: Node.jsプラグインに必要なキーリングのインポート処理

### 4. ツールのインストールと管理
- **バージョン指定インストール**: `.tool-versions`に記載されたツールを指定バージョンでインストール
- **reshim実行**: インストール後の実行可能ファイルのリンク更新
- **バージョン確認**: インストール後の各ツールバージョンを確認・表示

### 5. システム依存関係の整理
- **Debian/Ubuntu対応**: 開発に必要な基本パッケージの整理（curl, wget, git, gnupgなど）
- **macOS対応**: Homebrew経由での必要パッケージインストール
- **Python/Ruby開発対応**: SSL、FFI、zlib等の開発ライブラリの追加

## 技術的な詳細

### 実装された主要タスク
```yaml
# asdf設定
- name: Set asdf configuration
  set_fact:
    asdf_sh: "{{ brew.prefix }}/opt/asdf/libexec/asdf.sh"
    asdf_env:
      ASDF_DIR: "{{ brew.prefix }}/opt/asdf/libexec"
      PATH: "{{ ansible_env.PATH }}:{{ brew.prefix }}/opt/asdf/shims:{{ brew.prefix }}/opt/asdf/bin"

# .tool-versionsの解析
- name: Parse .tool-versions content
  set_fact:
    asdf_tools: >-
      {{ (tool_versions_raw.content | b64decode).splitlines()
      | map('trim')
      | reject('match', '^(#|$)')
      | map('split')
      | list }}
```

### エラーハンドリング
- **ファイル非存在時の適切なスキップ**: `.tool-versions`ファイルが存在しない場合の適切なメッセージ表示
- **プラグインインストール失敗の許容**: 一部プラグインのインストールが失敗しても全体の処理を継続
- **bashシェル環境の保証**: asdf関連コマンドの適切な実行環境確保

## 追加されたコミット履歴

1. **eb3a143**: 初期asdf設定とツール管理機能の実装
2. **7a1ab6e**: `.tool-versions`ファイル存在確認とスキップメッセージの追加
3. **35af024**: asdf環境変数設定とbashシェル使用の改善
4. **39722c8**: dotfilesサブプロジェクトの更新
5. **e070324**: システム依存関係インストールタスクの追加と整理

## 改善効果

### 開発環境構築の自動化
- 手動でのツールインストールが不要
- チーム内でのツールバージョン統一
- 新しい開発環境の迅速なセットアップ

### メンテナンス性の向上
- `.tool-versions`ファイルによる一元管理
- 各ツールのバージョン確認の自動化
- エラー時の適切な情報表示

## 注意事項
- 本PRはまだドラフト状態のため、マージ前にレビューが必要
- asdfがHomebrewでインストールされていることが前提
- bashシェル環境での実行が必要
