### PR TITLE
Fix/zsh environment compatibility

### DIFF
--- a/.github/workflows/ansible-basic-test.yml
+++ b/.github/workflows/ansible-basic-test.yml
@@ -7,6 +7,8 @@ on:
       - 'infra/**'
   pull_request:
     branches: [main]
+    paths:
+      - 'infra/**'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/ansible-basic-test.yml
+++ b/.github/workflows/ansible-basic-test.yml
@@ -2,11 +2,11 @@ name: Ansible Playbook Basic Test
 
 on:
   push:
-    branches: [main, feature/*, fix/*]
+    branches: [main]
     paths:
       - 'infra/**'
   pull_request:
-    branches: [main, feature/*, fix/*]
+    branches: [main, feature/*, fix/*, refactor/*]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/ansible-basic-test.yml
+++ b/.github/workflows/ansible-basic-test.yml
@@ -6,7 +6,7 @@ on:
     paths:
       - 'infra/**'
   pull_request:
-    branches: [main, feature/*, fix/*, refactor/*]
+    branches: [main]
   workflow_dispatch:
 
 env:

--- a/infra/playbook.yml
+++ b/infra/playbook.yml
@@ -169,6 +169,8 @@
             age_key_file: "{{ paths.age_key }}"
             brew_bin: "{{ brew.bin }}"
             brew_prefix: "{{ brew.prefix }}"
+            asdf_dir: "{{ brew.prefix }}/opt/asdf/libexec"
+            asdf_sh: "{{ brew.prefix }}/opt/asdf/libexec/asdf.sh"
 
         - name: Check existing repository
           stat:
@@ -190,20 +192,10 @@
           register: doctor_result
           changed_when: false
 
-        - name: Preview changes
-          command: "{{ brew.bin }}/chezmoi diff"
-          register: diff_result
-          changed_when: false
-          failed_when: false
-
-        - name: Display pending changes
-          debug:
-            msg: "{{ diff_result.stdout_lines }}"
-          when: diff_result.stdout != ""
-
         - name: Apply dotfiles
-          command: "{{ brew.bin }}/chezmoi apply -v"
+          command: "{{ brew.bin }}/chezmoi apply"
           register: apply_result
+          no_log: true
 
         - name: Create asdf compatibility symlink
           file:

--- a/infra/playbook.yml
+++ b/infra/playbook.yml
@@ -62,24 +62,11 @@
       shell: /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
       when: brew_check.rc != 0
 
-    - name: Configure shell environment
-      lineinfile:
-        path: "{{ paths.zprofile }}"
-        create: true
-        line: "{{ item }}"
-        state: present
-      loop:
-        - 'eval "$({{ brew.bin }}/brew shellenv)"'
-        - 'export AGE_IDENTITIES_FILE="{{ paths.age_key }}"'
-        - 'export ASDF_DIR="{{ brew.prefix }}/opt/asdf/libexec"'
-        - '. {{ asdf_sh }}'
-
     - name: Install essential system dependencies
       block:
         - name: Install core dependencies (Debian/Ubuntu)
           apt:
             name: 
-              # 基本ツール
               - build-essential
               - unzip
               - curl
@@ -89,7 +76,6 @@
               - dirmngr
               - ca-certificates
               - software-properties-common
-              # 開発用ライブラリ（Python/Ruby等で必要）
               - libssl-dev
               - libffi-dev
               - zlib1g-dev
@@ -110,7 +96,6 @@
             state: present
           when: ansible_facts.os_family == "Darwin"
 
-
     - name: Check existing packages
       command: "{{ brew.bin }}/brew list --versions {{ item }}"
       loop: "{{ packages }}"
@@ -123,28 +108,7 @@
       loop: "{{ package_check.results }}"
       when: item.rc != 0
 
-    - name: Configure zsh as default shell
-      block:
-        - name: Register zsh in /etc/shells
-          lineinfile:
-            path: /etc/shells
-            line: "{{ brew.zsh }}"
-            state: present
-          become: yes
-
-        - name: Get current shell
-          command: /bin/sh -lc 'echo "$SHELL"'
-          register: current_shell
-          changed_when: false
-
-        - name: Set default shell to zsh
-          user:
-            name: "{{ ansible_user_id }}"
-            shell: "{{ brew.zsh }}"
-          become: yes
-          when: current_shell.stdout != brew.zsh
-
-    - name: Configure zsh as default shell
+    - name: Configure zsh as default shell and install zplug
       block:
         - name: Install zplug plugin manager
           git:
@@ -203,6 +167,7 @@
           vars:
             age_public_key: "{{ age_public_key.stdout.strip() }}"
             age_key_file: "{{ paths.age_key }}"
+            brew_bin: "{{ brew.bin }}"
             brew_prefix: "{{ brew.prefix }}"
 
         - name: Check existing repository
@@ -236,29 +201,16 @@
             msg: "{{ diff_result.stdout_lines }}"
           when: diff_result.stdout != ""
 
-        - name: Ensure zshrc compatibility before chezmoi apply
-          block:
-            - name: Check if current .zshrc has compatibility issues
-              shell: "grep -q '\\$HOME/\\.asdf/asdf\\.sh' {{ paths.zshrc }} || grep -q 'source.*\\.asdf/asdf\\.sh' {{ paths.zshrc }}"
-              register: has_asdf_issues
-              failed_when: false
-              changed_when: false
-
-            - name: Create temporary compatibility fixes
-              replace:
-                path: "{{ paths.zshrc }}"
-                regexp: "{{ item.pattern }}"
-                replace: "{{ item.replacement }}"
-              loop:
-                - pattern: '(\.|source)\s+\$HOME/\.asdf/asdf\.sh'
-                  replacement: '. {{ asdf_sh }}'
-                - pattern: 'source\s+"\$HOME/\.asdf/completions/asdf\.bash"'
-                  replacement: '# Temporarily disabled - will be fixed by template'
-              when: has_asdf_issues.rc == 0
-
         - name: Apply dotfiles
           command: "{{ brew.bin }}/chezmoi apply -v"
           register: apply_result
+
+        - name: Create asdf compatibility symlink
+          file:
+            src: "{{ brew.prefix }}/opt/asdf"
+            dest: "{{ paths.home }}/.asdf"
+            state: link
+            force: yes
 
         - name: Get final status
           command: "{{ brew.bin }}/chezmoi status"
@@ -270,24 +222,31 @@
 
     - name: Verify zsh configuration
       block:
+        - name: Check if .zshrc exists
+          stat:
+            path: "{{ paths.zshrc }}"
+          register: zshrc_final_check
+
         - name: Test zsh configuration syntax
           shell: "{{ brew.zsh }} -n {{ paths.zshrc }}"
           register: zsh_syntax_check
           failed_when: false
+          when: zshrc_final_check.stat.exists
 
         - name: Test interactive zsh loading
           shell: "timeout 10 {{ brew.zsh }} -i -c 'echo ZSH_LOADED_OK && exit 0'"
           register: zsh_interactive_test
           failed_when: false
+          when: zshrc_final_check.stat.exists
 
         - name: Display verification results
           debug:
             msg:
               - "=== ZSH Configuration Verification ==="
-              - "Syntax Check: {{ 'PASSED' if zsh_syntax_check.rc == 0 else 'FAILED' }}"
-              - "Interactive Load: {{ 'PASSED' if zsh_interactive_test.rc == 0 else 'FAILED' }}"
-              - "{{ zsh_interactive_test.stdout if zsh_interactive_test.stdout else '' }}"
-    
+              - ".zshrc exists: {{ 'YES' if zshrc_final_check.stat.exists else 'NO' }}"
+              - "Syntax Check: {{ 'PASSED' if (zshrc_final_check.stat.exists and zsh_syntax_check.rc == 0) else 'SKIPPED/FAILED' }}"
+              - "Interactive Load: {{ 'PASSED' if (zshrc_final_check.stat.exists and zsh_interactive_test.rc == 0) else 'SKIPPED/FAILED' }}"
+
     - name: Check .tool-versions file exists
       stat:
         path: "{{ paths.tool_versions }}"
@@ -373,7 +332,6 @@
 
       environment: "{{ asdf_env }}"
       when: tool_versions_file.stat.exists
-
 
     - name: Display skip message
       debug:

--- a/infra/playbook.yml
+++ b/infra/playbook.yml
@@ -11,6 +11,7 @@
       age_key: "{{ ansible_env.HOME }}/.config/age/age.key"
       chezmoi_source: "{{ ansible_env.HOME }}/.local/share/chezmoi"
       zprofile: "{{ ansible_env.HOME }}/.zprofile"
+      zshrc: "{{ ansible_env.HOME }}/.zshrc"
       tool_versions: "{{ ansible_env.HOME }}/.tool-versions"
 
     brew_configs:
@@ -143,6 +144,34 @@
           become: yes
           when: current_shell.stdout != brew.zsh
 
+    - name: Configure zsh as default shell
+      block:
+        - name: Install zplug plugin manager
+          git:
+            repo: "https://github.com/zplug/zplug"
+            dest: "{{ paths.home }}/.zplug"
+            version: "master"
+            update: no
+
+        - name: Register zsh in /etc/shells
+          lineinfile:
+            path: /etc/shells
+            line: "{{ brew.zsh }}"
+            state: present
+          become: yes
+
+        - name: Get current shell
+          command: /bin/sh -lc 'echo "$SHELL"'
+          register: current_shell
+          changed_when: false
+
+        - name: Set default shell to zsh
+          user:
+            name: "{{ ansible_user_id }}"
+            shell: "{{ brew.zsh }}"
+          become: yes
+          when: current_shell.stdout != brew.zsh
+
     - name: Setup encryption and dotfiles management
       block:
         - name: Create configuration directories
@@ -207,6 +236,26 @@
             msg: "{{ diff_result.stdout_lines }}"
           when: diff_result.stdout != ""
 
+        - name: Ensure zshrc compatibility before chezmoi apply
+          block:
+            - name: Check if current .zshrc has compatibility issues
+              shell: "grep -q '\\$HOME/\\.asdf/asdf\\.sh' {{ paths.zshrc }} || grep -q 'source.*\\.asdf/asdf\\.sh' {{ paths.zshrc }}"
+              register: has_asdf_issues
+              failed_when: false
+              changed_when: false
+
+            - name: Create temporary compatibility fixes
+              replace:
+                path: "{{ paths.zshrc }}"
+                regexp: "{{ item.pattern }}"
+                replace: "{{ item.replacement }}"
+              loop:
+                - pattern: '(\.|source)\s+\$HOME/\.asdf/asdf\.sh'
+                  replacement: '. {{ asdf_sh }}'
+                - pattern: 'source\s+"\$HOME/\.asdf/completions/asdf\.bash"'
+                  replacement: '# Temporarily disabled - will be fixed by template'
+              when: has_asdf_issues.rc == 0
+
         - name: Apply dotfiles
           command: "{{ brew.bin }}/chezmoi apply -v"
           register: apply_result
@@ -218,6 +267,26 @@
 
       environment:
         AGE_IDENTITIES_FILE: "{{ paths.age_key }}"
+
+    - name: Verify zsh configuration
+      block:
+        - name: Test zsh configuration syntax
+          shell: "{{ brew.zsh }} -n {{ paths.zshrc }}"
+          register: zsh_syntax_check
+          failed_when: false
+
+        - name: Test interactive zsh loading
+          shell: "timeout 10 {{ brew.zsh }} -i -c 'echo ZSH_LOADED_OK && exit 0'"
+          register: zsh_interactive_test
+          failed_when: false
+
+        - name: Display verification results
+          debug:
+            msg:
+              - "=== ZSH Configuration Verification ==="
+              - "Syntax Check: {{ 'PASSED' if zsh_syntax_check.rc == 0 else 'FAILED' }}"
+              - "Interactive Load: {{ 'PASSED' if zsh_interactive_test.rc == 0 else 'FAILED' }}"
+              - "{{ zsh_interactive_test.stdout if zsh_interactive_test.stdout else '' }}"
     
     - name: Check .tool-versions file exists
       stat:

--- a/infra/templates/chezmoi.toml.j2
+++ b/infra/templates/chezmoi.toml.j2
@@ -13,6 +13,8 @@ user = "{{ ansible_user_id }}"
 brew_bin = "{{ brew_bin }}"
 brew_prefix = "{{ brew_prefix }}"
 age_key_file = "{{ age_key_file }}"
+asdf_dir = "{{ asdf_dir }}"
+asdf_sh = "{{ asdf_sh }}"
 is_darwin = {{ (ansible_facts.os_family == "Darwin") | lower }}
 is_linux = {{ (ansible_facts.os_family != "Darwin") | lower }}
 {% if ansible_facts.os_family == "Darwin" %}

--- a/infra/templates/chezmoi.toml.j2
+++ b/infra/templates/chezmoi.toml.j2
@@ -10,7 +10,9 @@ hostname = "{{ ansible_hostname }}"
 os = "{{ ansible_facts.os_family | lower }}"
 arch = "{{ ansible_facts.machine }}"
 user = "{{ ansible_user_id }}"
+brew_bin = "{{ brew_bin }}"
 brew_prefix = "{{ brew_prefix }}"
+age_key_file = "{{ age_key_file }}"
 is_darwin = {{ (ansible_facts.os_family == "Darwin") | lower }}
 is_linux = {{ (ansible_facts.os_family != "Darwin") | lower }}
 {% if ansible_facts.os_family == "Darwin" %}


### PR DESCRIPTION
## 概要
本PRは、zsh環境の互換性問題を解決し、開発環境のセットアップを強化することを目的としています。zplugプラグインマネージャーの導入、CI/CDワークフローの改善、dotfiles管理の最適化を通じて、より安定した開発環境の構築を実現しています。

## 主な変更内容
### 1. zsh環境の互換性強化
プラグインマネージャーの導入

zplugプラグインマネージャーのインストールと設定
.zshrcの互換性チェック機能の実装
デフォルトシェルとしてのzsh設定の改善
シェル環境の最適化

シェルの登録プロセスの強化
設定の検証機能の追加
環境構築プロセスの整合性向上

### 2. CI/CDワークフローの改善
Ansible基本テストワークフローの最適化

ブランチ指定の修正（pushイベントでmainブランチのみ）
pull_requestイベントでのrefactor/*ブランチの追加
テスト対象パスに'infra/**'を追加
テスト対象の明確化

関連する変更がテスト対象に含まれるよう改善
テスト実行の効率化

### 3. dotfiles管理の強化
chezmoi設定の拡張

brew_binとage_key_fileをテンプレートに追加
asdf関連のディレクトリとスクリプトパスを追加
dotfiles適用時のログ出力抑制
設定管理の最適化

不要な変更プレビュータスクの削除
設定の適用プロセスの簡素化

### 4. サブプロジェクト管理
依存関係の更新

サブプロジェクトのコミットIDを段階的に更新
依存関係の最新状態を反映
-dirtyフラグを追加して状態変更を明示化

## 技術的な詳細
### 実装されたコミット履歴
a1729f9: サブプロジェクトのコミットIDに-dirtyを追加し、状態の変更を明示化
145d201: zshのデフォルトシェル設定と.zshrcの互換性チェックを追加、zplugプラグインマネージャーのインストール
30d3c4e: Ansible基本テストワークフローのブランチ指定を修正
587024d: pull_requestイベントの対象ブランチをmainのみに変更
827e8d0: テスト対象のパスに'infra/**'を追加
5168192: zshのデフォルトシェル設定を改善、.zshrcの互換性チェックを削除
7ba6c19: サブプロジェクトのコミットIDをf23b10aに更新
53d28b0: chezmoi設定にasdf関連設定を追加、dotfiles適用時のログ出力を抑制
d2cffd2: サブプロジェクトのコミットIDをf932c82に更新